### PR TITLE
ci: group dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
         update-types:
           - minor
           - patch
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -56,3 +60,7 @@ updates:
         update-types:
           - minor
           - patch
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds an `applies-to: security-updates` group to each Dependabot ecosystem so future security advisories land as a single grouped PR (per ecosystem) instead of one PR per advisory
- Cooldown still doesn't apply to security updates by design — the group appears immediately when advisories open

## Why

Enabling Dependabot security updates earlier today spawned 6 individual PRs from the existing alert backlog. Grouping consolidates that into one PR per ecosystem going forward — less PR noise, one CI run, one auto-merge action.

## Test plan

- [ ] CI `build` passes on this PR
- [ ] After merge, when the next security advisory is published, confirm Dependabot opens a single grouped PR (title pattern: `deps: bump the npm-security group with N updates`) instead of one per package