### PR TITLE
fix(ci): drop unsupported semver-days from github-actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,9 +49,6 @@ updates:
       - "github-actions"
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
       include:
         - "*"
     groups:


### PR DESCRIPTION
## Summary

Removes `semver-major-days` / `semver-minor-days` / `semver-patch-days` from the **github-actions** ecosystem's cooldown block. The github-actions ecosystem doesn't accept these — GitHub Action tags aren't strict semver — and Dependabot has been rejecting the whole file with `"invalid details"` since PR #24 landed.

`default-days: 7` is retained and applies uniformly to action updates.

## How this slipped through

The Dependabot config-validation check (`.github/dependabot.yml`) only runs on commits to the default branch. On PR #24 the file had the same flaw, but the validation check fires post-merge, not on the PR. So neither the PR's `build` check nor the auto-merge workflow caught it — it only surfaced once committed to `main`.

The npm ecosystem block was unaffected (npm does support semver-specific cooldown), which is why we've still been seeing npm Dependabot PRs come through during the session.

## Test plan

- [ ] Merge → check the `.github/dependabot.yml` status check on `main` is green
- [ ] Trigger a github-actions update via *Insights → Dependency graph → Dependabot* to confirm the ecosystem now runs