### PR TITLE
ci: use PAT for release-please so PR triggers Build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: node
-          # Use the default GITHUB_TOKEN with proper permissions
-          token: ${{ github.token }}
+          # PAT required so the release PR is authored by a user account.
+          # GitHub suppresses pull_request workflow triggers on events created
+          # by GITHUB_TOKEN, leaving the required Build check un-run.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
 
 


### PR DESCRIPTION
## Summary
- Switches release-please from `${{ github.token }}` to `${{ secrets.RELEASE_PLEASE_TOKEN }}` (fine-grained PAT)
- Fixes release PRs (e.g. #48) getting stuck at branch protection because the required `Build` check never fires

## Why
GitHub deliberately suppresses `pull_request` workflow triggers on events created by `GITHUB_TOKEN` to prevent infinite loops ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). Release-please PRs created by `GITHUB_TOKEN` therefore never trigger our [Build workflow](.github/workflows/checks.yml), and branch protection blocks them indefinitely.

A PAT-authored event triggers workflows normally.

## Test plan
- [ ] This PR itself runs `Build` (sanity check that branch protection works as expected)
- [ ] After merge, release-please runs and the next release PR triggers `Build` naturally
- [ ] Confirm #48 also re-triggers (release-please will re-author the branch when it next runs against main)