### PR TITLE
feat!: replace astro-seo with BaseHead component + src/consts.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "astro": "^6.3.3",
         "astro-expressive-code": "^0.42.0",
         "astro-pagefind": "^1.8.6",
-        "astro-seo": "^1.1.0",
         "daisyui": "^5.5.14",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -94,6 +93,7 @@
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
       "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/language-server": "^2.16.7",
@@ -112,6 +112,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -127,6 +128,7 @@
       "version": "2.16.8",
       "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.8.tgz",
       "integrity": "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
@@ -278,6 +280,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
       "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"
@@ -1098,6 +1101,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
       "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
@@ -1107,6 +1111,7 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
       "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emmetio/scanner": "^1.0.4"
@@ -1116,6 +1121,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
       "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emmetio/stream-reader": "^2.2.0",
@@ -1126,6 +1132,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
       "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@emmetio/scanner": "^1.0.0"
@@ -1135,18 +1142,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
       "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
       "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
       "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
@@ -3399,6 +3409,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
       "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-service": "2.4.28",
@@ -3415,6 +3426,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
       "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.28"
@@ -3424,6 +3436,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
       "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -3441,6 +3454,7 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
       "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -3453,12 +3467,14 @@
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
       "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
       "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.28",
@@ -3470,6 +3486,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
       "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emmet": "^2.4.3",
@@ -3483,12 +3500,14 @@
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3505,6 +3524,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
@@ -3718,15 +3738,6 @@
         "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6"
       }
     },
-    "node_modules/astro-seo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/astro-seo/-/astro-seo-1.1.0.tgz",
-      "integrity": "sha512-G6LDNDyga30o+52v58jU7C35n3cORUzk7RSuY+xf/ZRbW6JiNplyaOO1VoYVKO+xzYNaBcxqNln2RFRR/wgJNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/check": "^0.9.0"
-      }
-    },
     "node_modules/astro/node_modules/@astrojs/compiler": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
@@ -3934,6 +3945,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3964,6 +3976,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3978,6 +3991,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3987,6 +4001,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4002,12 +4017,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4022,6 +4039,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4034,6 +4052,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -4060,6 +4079,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4072,6 +4092,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -4573,6 +4594,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
       "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
       "license": "MIT",
       "workspaces": [
         "./packages/scanner",
@@ -4764,6 +4786,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -4785,6 +4808,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4918,6 +4942,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5350,6 +5375,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5559,6 +5585,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5577,12 +5604,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6719,6 +6748,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6976,6 +7006,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
@@ -7140,6 +7171,7 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -7155,7 +7187,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
@@ -7314,6 +7346,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -7502,12 +7535,14 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
       "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7517,6 +7552,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7650,14 +7686,14 @@
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
       "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
       "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "suf-log": "^2.5.3"
@@ -7938,7 +7974,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
       "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "s.color": "0.0.15"
@@ -8138,12 +8174,14 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
       "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8157,6 +8195,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
       "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.8"
@@ -8166,6 +8205,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8773,6 +8813,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
       "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-css-languageservice": "^6.3.0",
@@ -8792,6 +8833,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
       "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emmetio/css-parser": "^0.4.1",
@@ -8812,6 +8854,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
       "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-html-languageservice": "^5.3.0",
@@ -8831,6 +8874,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
       "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
@@ -8852,6 +8896,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
       "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-browserify": "^1.0.1",
@@ -8874,6 +8919,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
       "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8"
@@ -8891,6 +8937,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8903,6 +8950,7 @@
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
       "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-uri": "^3.0.8",
@@ -8921,6 +8969,7 @@
       "version": "6.3.10",
       "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
       "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -8933,6 +8982,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
       "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -8945,6 +8995,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
       "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.0.0",
@@ -8961,12 +9012,14 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
       "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -8976,6 +9029,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
       "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.17.5"
@@ -8988,6 +9042,7 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
@@ -8998,24 +9053,28 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
       "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
@@ -9162,6 +9221,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -9177,6 +9237,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -9192,6 +9253,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
       "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -9214,12 +9276,14 @@
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
       "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -9232,6 +9296,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9250,6 +9315,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -9259,6 +9325,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9268,12 +9335,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9288,6 +9357,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "astro": "^6.3.3",
     "astro-expressive-code": "^0.42.0",
     "astro-pagefind": "^1.8.6",
-    "astro-seo": "^1.1.0",
     "daisyui": "^5.5.14",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,0 +1,84 @@
+---
+/**
+ * BaseHead — emits every meta tag a page needs.
+ *
+ * Pattern follows the official Astro blog example
+ * (`withastro/astro/examples/blog/src/components/BaseHead.astro`).
+ *
+ * Emits unconditionally: charset, viewport, favicon, generator, sitemap link,
+ * RSS link, <link rel="canonical">, OpenGraph, Twitter Card, JSON-LD Organization.
+ */
+import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import logo from "../assets/logo.svg";
+
+export interface Props {
+  title?: string;
+  description?: string;
+  /** Absolute URL for the OpenGraph / Twitter card image */
+  image?: string;
+  /** Adds robots: noindex, nofollow */
+  noindex?: boolean;
+}
+
+const { title, description, image, noindex } = Astro.props;
+
+const pageTitle = title ? `${title} – ${SITE_TITLE}` : SITE_TITLE;
+const pageDescription = description ?? SITE_DESCRIPTION;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const logoUrl = new URL(logo.src, Astro.site).href;
+const ogImage = image ?? logoUrl;
+---
+
+<!-- Global -->
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<meta name="generator" content={Astro.generator} />
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title={`${SITE_TITLE} RSS Feed`}
+  href="/rss.xml"
+/>
+
+<!-- Canonical -->
+<link rel="canonical" href={canonicalURL} />
+
+<!-- Primary meta -->
+<title>{pageTitle}</title>
+<meta name="title" content={pageTitle} />
+<meta name="description" content={pageDescription} />
+
+{noindex && <meta name="robots" content="noindex, nofollow" />}
+
+<!-- OpenGraph -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:site_name" content={SITE_TITLE} />
+<meta property="og:title" content={pageTitle} />
+<meta property="og:description" content={pageDescription} />
+<meta property="og:image" content={ogImage} />
+<meta property="og:image:alt" content={pageTitle} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+
+<!-- Twitter -->
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:url" content={canonicalURL} />
+<meta property="twitter:title" content={pageTitle} />
+<meta property="twitter:description" content={pageDescription} />
+<meta property="twitter:image" content={ogImage} />
+
+<!-- JSON-LD Organization -->
+<script
+  type="application/ld+json"
+  set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: SITE_TITLE,
+    url: Astro.site,
+    logo: logoUrl,
+    sameAs: ["https://www.youtube.com/@StarGarden"],
+  })}
+/>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,6 @@
+/**
+ * Site-wide constants imported throughout the template.
+ * Edit these when forking to brand the template for your own site.
+ */
+export const SITE_TITLE = "StarGarden";
+export const SITE_DESCRIPTION = "StarGarden – a customizable Astro theme";

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,72 +2,22 @@
 import "../styles/global.css";
 import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
-import logo from "../assets/logo.svg";
-
-import { SEO } from "astro-seo";
+import BaseHead from "../components/BaseHead.astro";
 
 export interface Props {
-  /** Optional granular SEO overrides coming from .astro pages or components */
-  seo?: {
-    title?: string;
-    description?: string;
-    /** Absolute URL for the OpenGraph image */
-    image?: string;
-    /** Set to true to add a noindex robots directive */
-    noindex?: boolean;
-  };
-  /** Standard front‑matter fields coming from Markdown/MDX pages */
   title?: string;
   description?: string;
+  /** Absolute URL for the OpenGraph / Twitter card image */
+  image?: string;
+  noindex?: boolean;
 }
 
-const defaultDescription = "StarGarden – a customizable Astro theme";
-const logoUrl = new URL(logo.src, Astro.site).href;
-
-// Destructure front‑matter fields as well as the existing `seo` object
-const { seo = {}, title, description } = Astro.props;
-
-/** Merge explicit `seo` overrides with any front‑matter fields.
- *  Values defined in `seo` win over front‑matter, preserving backward compatibility.
- */
-const pageTitle = seo.title ?? title;
-const pageDescription = seo.description ?? description ?? defaultDescription;
-
-/** Build OpenGraph configuration when a page title is available */
-const openGraph = pageTitle
-  ? {
-      basic: {
-        title: pageTitle,
-        type: seo.image ? "article" : "website",
-        image: seo.image ?? logoUrl,
-      },
-      optional: {
-        description: pageDescription,
-        siteName: "StarGarden",
-      },
-      image: {
-        alt: pageTitle,
-        width: 1200,
-        height: 630,
-      },
-    }
-  : undefined;
-
-/** Single props object for the SEO component */
-const seoProps = {
-  title: pageTitle,
-  description: pageDescription,
-  titleTemplate: "%s – StarGarden",
-  titleDefault: "StarGarden Theme",
-  ...(seo.noindex ? { noindex: true, nofollow: true } : {}),
-  ...(openGraph ? { openGraph } : {}),
-};
+const { title, description, image, noindex } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en" data-theme="corporate">
   <head>
-    <meta charset="utf-8" />
     <!-- Persisted theme (dark / light) is applied as early as possible -->
     <script is:inline>
       const savedTheme = localStorage.getItem("theme");
@@ -75,29 +25,13 @@ const seoProps = {
         document.documentElement.setAttribute("data-theme", savedTheme);
       }
     </script>
-    <SEO {...seoProps} />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      noindex={noindex}
+    />
     <slot name="head" />
-    <script
-      type="application/ld+json"
-      set:html={JSON.stringify({
-        "@context": "https://schema.org",
-        "@type": "Organization",
-        name: "StarGarden",
-        url: Astro.site,
-        logo: logoUrl,
-        sameAs: ["https://www.youtube.com/@StarGarden"],
-      })}
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="Stargarden RSS Feed"
-      href="/rss.xml"
-    />
-    <meta name="generator" content={Astro.generator} />
   </head>
 
   <body

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -16,9 +16,7 @@ if (coverImg && typeof coverImg === "string" && assetMap[coverImg as string]) {
 }
 ---
 
-<Layout
-  seo={{ title: frontmatter.title, description: frontmatter.description }}
->
+<Layout title={frontmatter.title} description={frontmatter.description}>
   <div class="flex flex-col items-center">
     <h1 class="mb-4 text-3xl font-bold">{frontmatter.title}</h1>
     <p class="text-accent mb-4 text-sm font-bold">{frontmatter.date}</p>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,11 +5,9 @@ import notFound from "../assets/404.png";
 ---
 
 <Layout
-  seo={{
-    title: "Page Not Found",
-    description: "We couldn't find that page.",
-    noindex: true,
-  }}
+  title="Page Not Found"
+  description="We couldn't find that page."
+  noindex={true}
 >
   <section class="flex min-h-[60vh] items-center">
     <div class="container mx-auto w-full px-4">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,11 +7,8 @@ const posts = await getCollection("posts", ({ data }) => !data.draft);
 ---
 
 <Layout
-  seo={{
-    title: "Home",
-    description:
-      "StarGarden – a customizable Astro theme for blogs and content sites.",
-  }}
+  title="Home"
+  description="StarGarden – a customizable Astro theme for blogs and content sites."
 >
   <Landing />
 

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -16,11 +16,9 @@ const ogImage = new URL(post.data.cover.src, Astro.site).href;
 ---
 
 <Layout
-  seo={{
-    title: post.data.title,
-    description: post.data.description,
-    image: ogImage,
-  }}
+  title={post.data.title}
+  description={post.data.description}
+  image={ogImage}
 >
   <article class="prose mx-auto max-w-2xl">
     <h1>{post.data.title}</h1>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -6,10 +6,8 @@ const posts = await getCollection("posts", ({ data }) => !data.draft);
 ---
 
 <Layout
-  seo={{
-    title: "Posts",
-    description: "A collection of blog posts about stars and astronomy.",
-  }}
+  title="Posts"
+  description="A collection of blog posts about stars and astronomy."
 >
   <h1 class="p-4 text-2xl font-semibold">Posts</h1>
   <div class="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary

Replaces the `astro-seo` integration with a hand-rolled `BaseHead.astro` component following the official Astro blog example pattern. Adds `src/consts.ts` for site-wide constants.

## Implements

Closes #53

## Why

- Current `astro-seo` setup skips Twitter Card meta entirely, omits `<link rel="canonical">`, and only emits OpenGraph when an explicit title is set. Homepage ships without OG tags.
- The official Astro docs do not reference `astro-seo` anywhere; the canonical pattern (per `withastro/astro/examples/blog`) is a hand-rolled `BaseHead.astro`.

## What changed

- **New** `src/consts.ts` exporting `SITE_TITLE` and `SITE_DESCRIPTION` (matches official blog example exactly)
- **New** `src/components/BaseHead.astro` emitting unconditionally: charset, viewport, favicon, generator, sitemap link, RSS link, canonical, full OpenGraph block, Twitter Card, and Organization JSON-LD
- **Refactored** `src/layouts/Layout.astro` to render `<BaseHead />` in `<head>`. Prop interface flattened from `seo?: { ... }` to flat `title` / `description` / `image` / `noindex`
- **Updated** 5 Layout consumers: `pages/index.astro`, `pages/posts/index.astro`, `pages/posts/[slug].astro`, `pages/404.astro`, `layouts/Markdown.astro`
- **Removed** `astro-seo` from `package.json`

## Breaking change

The Layout's `seo` prop is replaced. Migration in the commit footer; release-please will pull it into the 2.0.0 changelog.

## Test plan

- [x] `npm run build` succeeds and emits expected meta tags (verified `dist/index.html` contains canonical, OG, Twitter, and JSON-LD blocks)
- [x] `npm test` passes (3 files / 6 tests)
- [x] `npm run format:check` passes
- [ ] CI green