### PR TITLE
feat: add reading time and heading anchors to posts

### DIFF
--- a/__tests__/astroConfig.test.ts
+++ b/__tests__/astroConfig.test.ts
@@ -37,6 +37,10 @@ interface AstroConfigShape {
   readonly vite?: {
     readonly plugins?: PluginStub[];
   };
+  readonly markdown?: {
+    readonly remarkPlugins?: ReadonlyArray<unknown>;
+    readonly rehypePlugins?: ReadonlyArray<unknown>;
+  };
 }
 
 const tailwindPluginStub: PluginStub = { name: "@tailwindcss/vite" };
@@ -107,5 +111,20 @@ describe("astro.config.mjs", () => {
       borderRadius: "0.5rem",
       frames: { shadowColor: "#124" },
     });
+  });
+
+  it("wires reading-time and heading-anchor markdown plugins", () => {
+    const remarkPlugins = config.markdown?.remarkPlugins ?? [];
+    expect(remarkPlugins).toHaveLength(1);
+    expect(typeof remarkPlugins[0]).toBe("function");
+
+    const rehypePlugins = config.markdown?.rehypePlugins ?? [];
+    expect(rehypePlugins).toHaveLength(2);
+    // rehype-slug entry is the bare plugin function
+    expect(typeof rehypePlugins[0]).toBe("function");
+    // rehype-autolink-headings entry is [plugin, options]
+    expect(Array.isArray(rehypePlugins[1])).toBe(true);
+    const autolinkEntry = rehypePlugins[1] as [unknown, { behavior: string }];
+    expect(autolinkEntry[1]).toMatchObject({ behavior: "wrap" });
   });
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,10 @@ import astroExpressiveCode from "astro-expressive-code";
 
 import pagefind from "astro-pagefind";
 
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import { remarkReadingTime } from "./src/plugins/remark-reading-time.mjs";
+
 const expressiveCode = astroExpressiveCode({
   // You can set configuration options here
   themes: ["github-dark"],
@@ -26,6 +30,10 @@ export default defineConfig({
   site: "https://stargarden.pages.dev",
   vite: {
     plugins: [tailwindcss()],
+  },
+  markdown: {
+    remarkPlugins: [remarkReadingTime],
+    rehypePlugins: [rehypeSlug, [rehypeAutolinkHeadings, { behavior: "wrap" }]],
   },
   integrations: [sitemap(), pagefind(), expressiveCode],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
         "astro-expressive-code": "^0.42.0",
         "astro-pagefind": "^1.8.6",
         "daisyui": "^5.5.14",
+        "mdast-util-to-string": "^4.0.0",
+        "reading-time": "^1.5.0",
+        "rehype-autolink-headings": "^7.1.0",
+        "rehype-slug": "^6.0.0",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -4672,6 +4676,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -6871,6 +6888,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+      "license": "MIT"
+    },
     "node_modules/regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
@@ -6911,6 +6934,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-expressive-code": {
       "version": "0.42.0",
       "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.42.0.tgz",
@@ -6944,6 +6985,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "astro-expressive-code": "^0.42.0",
     "astro-pagefind": "^1.8.6",
     "daisyui": "^5.5.14",
+    "mdast-util-to-string": "^4.0.0",
+    "reading-time": "^1.5.0",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-slug": "^6.0.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -11,7 +11,7 @@ export async function getStaticPaths() {
 const { slug } = Astro.params;
 const post = await getEntry("posts", slug);
 if (!post) throw new Error(`Post “${slug}” not found`);
-const { Content } = await render(post);
+const { Content, remarkPluginFrontmatter } = await render(post);
 const ogImage = new URL(post.data.cover.src, Astro.site).href;
 ---
 
@@ -24,6 +24,9 @@ const ogImage = new URL(post.data.cover.src, Astro.site).href;
     <h1>{post.data.title}</h1>
     <p class="mb-4 text-sm font-bold">
       {post.data.date.toLocaleDateString()}
+      <span class="text-base-content/60 ml-2 font-normal"
+        >· {remarkPluginFrontmatter.minutesRead}</span
+      >
     </p>
     <Image
       src={post.data.cover}

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,8 +1,19 @@
 ---
-import { getCollection } from "astro:content";
+import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import { Image } from "astro:assets";
-const posts = await getCollection("posts", ({ data }) => !data.draft);
+
+const rawPosts = await getCollection("posts", ({ data }) => !data.draft);
+const posts = await Promise.all(
+  rawPosts.map(async (post) => {
+    const { remarkPluginFrontmatter } = await render(post);
+    return { post, minutesRead: remarkPluginFrontmatter.minutesRead };
+  }),
+);
+posts.sort(
+  (a, b) =>
+    new Date(b.post.data.date).getTime() - new Date(a.post.data.date).getTime(),
+);
 ---
 
 <Layout
@@ -12,31 +23,27 @@ const posts = await getCollection("posts", ({ data }) => !data.draft);
   <h1 class="p-4 text-2xl font-semibold">Posts</h1>
   <div class="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 lg:grid-cols-3">
     {
-      posts
-        .sort(
-          (a, b) =>
-            new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
-        )
-        .map((v) => (
-          <a
-            href={`/posts/${v.id}/`}
-            class="card bg-base-100 shadow-xl transition-shadow duration-300 ease-in-out hover:shadow-2xl"
-          >
-            <Image
-              src={v.data.cover}
-              alt={v.data.title}
-              width={560}
-              height={315}
-              class="h-auto w-full object-cover"
-            />
-            <div class="card-body">
-              <h2 class="card-title">{v.data.title}</h2>
-              <p class="text-base-content/70 text-sm">
-                {new Date(v.data.date).toLocaleDateString()}
-              </p>
-            </div>
-          </a>
-        ))
+      posts.map(({ post, minutesRead }) => (
+        <a
+          href={`/posts/${post.id}/`}
+          class="card bg-base-100 shadow-xl transition-shadow duration-300 ease-in-out hover:shadow-2xl"
+        >
+          <Image
+            src={post.data.cover}
+            alt={post.data.title}
+            width={560}
+            height={315}
+            class="h-auto w-full object-cover"
+          />
+          <div class="card-body">
+            <h2 class="card-title">{post.data.title}</h2>
+            <p class="text-base-content/70 text-sm">
+              {new Date(post.data.date).toLocaleDateString()}
+              <span class="text-base-content/60 ml-1">· {minutesRead}</span>
+            </p>
+          </div>
+        </a>
+      ))
     }
   </div>
 </Layout>

--- a/src/plugins/remark-reading-time.mjs
+++ b/src/plugins/remark-reading-time.mjs
@@ -1,0 +1,21 @@
+import getReadingTime from "reading-time";
+import { toString } from "mdast-util-to-string";
+
+/**
+ * Remark plugin that calculates reading time from the markdown body and
+ * writes it into Astro's frontmatter as `minutesRead`.
+ *
+ * Per the Astro reading-time recipe:
+ * https://docs.astro.build/en/recipes/reading-time/
+ *
+ * Access the value via the second element of `render(entry)`:
+ *   const { Content, remarkPluginFrontmatter } = await render(post);
+ *   remarkPluginFrontmatter.minutesRead
+ */
+export function remarkReadingTime() {
+  return function (tree, { data }) {
+    const textOnPage = toString(tree);
+    const readingTime = getReadingTime(textOnPage);
+    data.astro.frontmatter.minutesRead = readingTime.text;
+  };
+}


### PR DESCRIPTION
## Summary

Adds two docs-blessed blog UX features: per-post reading time (Astro recipe at `/en/recipes/reading-time/`) and clickable heading anchors (Astro markdown docs at `/en/guides/markdown-content/#heading-ids-and-plugins`).

## Implements

Closes #55

## What changed

- New deps: `reading-time`, `mdast-util-to-string`, `rehype-slug`, `rehype-autolink-headings`
- `src/plugins/remark-reading-time.mjs`: custom remark plugin writing `minutesRead` into Astro frontmatter via `vfile.data.astro.frontmatter`
- `astro.config.mjs`: new `markdown` block wiring the remark plugin + `rehypeSlug` + `[rehypeAutolinkHeadings, { behavior: 'wrap' }]`
- `src/pages/posts/[slug].astro` displays `remarkPluginFrontmatter.minutesRead` next to the publish date
- `src/pages/posts/index.astro` renders each post to pull the same value so listing cards also show reading time
- `__tests__/astroConfig.test.ts`: new test asserts the markdown plugin shape (remark function + rehype slug + rehype autolink pair with `behavior: 'wrap'`)

## Test plan

- [x] `npm run build` succeeds; built post HTML contains heading IDs (`<h2 id="...">`) and anchor wrappers (`href="#..."`)
- [x] Reading time appears in built post HTML (`min read` string verified)
- [x] `npm test` passes (3 files, 7 tests — one new)
- [x] `npm run format:check` passes
- [ ] CI green