### PR TITLE
feat: include full post content and cover enclosure in RSS feed

### DIFF
--- a/__tests__/rss.test.ts
+++ b/__tests__/rss.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildRssItem, type RssPost } from "../src/lib/rss";
+
+const site = new URL("https://stargarden.pages.dev");
+
+function makePost(overrides: Partial<RssPost> = {}): RssPost {
+  return {
+    id: "black-holes",
+    body: "# A test heading\n\nBody copy with [a link](/foo) and **emphasis**.",
+    data: {
+      title: "Black Holes",
+      description: "A short description.",
+      date: new Date("2025-05-04T00:00:00Z"),
+      cover: { src: "/_astro/cover.abc.webp", format: "webp" },
+    },
+    ...overrides,
+  };
+}
+
+describe("buildRssItem", () => {
+  it("emits title, pubDate, description, link, and rendered HTML content", () => {
+    const post = makePost();
+    const item = buildRssItem(post, site);
+
+    expect(item.title).toBe("Black Holes");
+    expect(item.pubDate).toEqual(new Date("2025-05-04T00:00:00Z"));
+    expect(item.description).toBe("A short description.");
+    expect(item.link).toBe("/posts/black-holes/");
+    expect(item.content).toContain("<h1");
+    expect(item.content).toContain("A test heading");
+    expect(item.content).toContain('<a href="/foo"');
+    expect(item.content).toContain("<strong>emphasis</strong>");
+  });
+
+  it("attaches an enclosure with absolute URL when the post has a cover", () => {
+    const post = makePost();
+    const item = buildRssItem(post, site);
+
+    expect(item.enclosure).toBeDefined();
+    expect(item.enclosure?.url).toBe(
+      "https://stargarden.pages.dev/_astro/cover.abc.webp",
+    );
+    expect(item.enclosure?.length).toBe(0);
+    expect(item.enclosure?.type).toBe("image/webp");
+  });
+
+  it("omits the enclosure when the post has no cover", () => {
+    const post = makePost({
+      data: {
+        title: "No cover",
+        description: "still valid",
+        date: new Date("2025-01-01T00:00:00Z"),
+      },
+    });
+    const item = buildRssItem(post, site);
+
+    expect(item.enclosure).toBeUndefined();
+  });
+
+  it("allows <img> tags through the sanitizer (per Astro RSS docs)", () => {
+    const post = makePost({
+      body: "![alt](https://example.com/x.png)",
+    });
+    const item = buildRssItem(post, site);
+
+    expect(item.content).toContain('<img src="https://example.com/x.png"');
+    expect(item.content).toContain('alt="alt"');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,12 @@
         "astro-expressive-code": "^0.42.0",
         "astro-pagefind": "^1.8.6",
         "daisyui": "^5.5.14",
+        "markdown-it": "^14.1.1",
         "mdast-util-to-string": "^4.0.0",
         "reading-time": "^1.5.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
+        "sanitize-html": "^2.17.4",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -28,6 +30,8 @@
         "@commitlint/config-conventional": "^21.0.1",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.19",
+        "@types/markdown-it": "^14.1.2",
+        "@types/sanitize-html": "^2.16.1",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "prettier-plugin-astro": "^0.14.1",
@@ -2909,6 +2913,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2917,6 +2939,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2940,6 +2969,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
       }
     },
     "node_modules/@types/sax": {
@@ -3988,6 +4027,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4023,6 +4068,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/defu": {
@@ -4897,6 +4951,37 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -5034,6 +5119,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -5192,6 +5286,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/lightningcss": {
@@ -5450,6 +5553,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -5478,6 +5590,35 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -5720,6 +5861,12 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -6552,6 +6699,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -6863,6 +7016,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7261,6 +7423,33 @@
       "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/sass-formatter": {
       "version": "0.7.9",
@@ -7771,6 +7960,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "astro-expressive-code": "^0.42.0",
     "astro-pagefind": "^1.8.6",
     "daisyui": "^5.5.14",
+    "markdown-it": "^14.1.1",
     "mdast-util-to-string": "^4.0.0",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
+    "sanitize-html": "^2.17.4",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
@@ -35,6 +37,8 @@
     "@commitlint/config-conventional": "^21.0.1",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.19",
+    "@types/markdown-it": "^14.1.2",
+    "@types/sanitize-html": "^2.16.1",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,71 @@
+import MarkdownIt from "markdown-it";
+import sanitizeHtml from "sanitize-html";
+
+const parser = new MarkdownIt();
+
+/**
+ * Minimal post shape consumed by `buildRssItem`.
+ *
+ * Kept structural (not `CollectionEntry<'posts'>`) so unit tests can construct
+ * fixtures inline without dragging in the `astro:content` runtime.
+ */
+export interface RssPost {
+  id: string;
+  body?: string;
+  data: {
+    title: string;
+    description: string;
+    date: Date;
+    cover?: {
+      src: string;
+      format: string;
+    };
+  };
+}
+
+export interface RssEnclosure {
+  url: string;
+  length: number;
+  type: string;
+}
+
+export interface RssItem {
+  title: string;
+  pubDate: Date;
+  description: string;
+  link: string;
+  content: string;
+  enclosure?: RssEnclosure;
+}
+
+/**
+ * Build a single RSS item from a post collection entry.
+ *
+ * Renders the markdown body through markdown-it + sanitize-html (allowing
+ * `<img>` per the docs at /en/recipes/rss/#including-full-post-content) and
+ * attaches the cover image as an `enclosure` when present.
+ *
+ * Pure function — no Astro context required beyond the absolute site URL,
+ * so callers can fixture this directly in unit tests.
+ */
+export function buildRssItem(post: RssPost, site: URL): RssItem {
+  const item: RssItem = {
+    title: post.data.title,
+    pubDate: post.data.date,
+    description: post.data.description,
+    link: `/posts/${post.id}/`,
+    content: sanitizeHtml(parser.render(post.body ?? ""), {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+    }),
+  };
+
+  if (post.data.cover) {
+    item.enclosure = {
+      url: new URL(post.data.cover.src, site).href,
+      length: 0,
+      type: `image/${post.data.cover.format}`,
+    };
+  }
+
+  return item;
+}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,8 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
+import { buildRssItem } from "../lib/rss";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 
 /**
  * Generates an RSS feed for the blog.
@@ -8,19 +10,15 @@ import type { APIContext } from "astro";
  */
 export async function GET(context: APIContext) {
   const posts = await getCollection("posts", ({ data }) => !data.draft);
+  const site = context.site!;
 
   return rss({
-    title: "Stargarden Blog",
-    description: "A blog about the cosmos and beyond",
-    site: context.site!,
+    title: `${SITE_TITLE} Blog`,
+    description: SITE_DESCRIPTION,
+    site,
     items: posts
       .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-      .map((post) => ({
-        title: post.data.title,
-        pubDate: post.data.date,
-        description: post.data.description,
-        link: `/posts/${post.id}/`,
-      })),
+      .map((post) => buildRssItem(post, site)),
     customData: "<language>en-us</language>",
   });
 }


### PR DESCRIPTION
## Summary

Upgrades the RSS feed at `/rss.xml` from description-only to full-HTML-content per Astro's official recipe at `/en/recipes/rss/#including-full-post-content`. Adds cover-image enclosures.

## Implements

Closes #56

## What changed

- New deps: `markdown-it`, `sanitize-html`, `@types/markdown-it`, `@types/sanitize-html`
- New pure helper at `src/lib/rss.ts`: `buildRssItem(post, site)` returns `{ title, pubDate, description, link, content, enclosure? }`
  - Renders post body through `MarkdownIt`, sanitizes via `sanitize-html` allowing `<img>` per the docs
  - Attaches `enclosure { url, length, type }` when `post.data.cover` exists
  - Uses a local `RssPost` interface (structural, not `CollectionEntry<'posts'>`) so unit tests can fixture without dragging in `astro:content`
- `src/pages/rss.xml.ts` composes items via `buildRssItem`. Feed title/description now sourced from `SITE_TITLE` / `SITE_DESCRIPTION`
- New `__tests__/rss.test.ts` with 4 unit tests: full shape, enclosure with cover, enclosure omitted without cover, sanitizer allowing inline `<img>`

## Test plan

- [x] `npm test` passes (4 files, 11 tests — 4 new)
- [x] `npm run build` succeeds
- [x] Generated `dist/rss.xml` contains both `<content:encoded>` and `<enclosure>` for each item with cover
- [x] `npm run format:check` passes
- [ ] CI green