### PR TITLE
feat: add dynamic robots.txt endpoint

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from "astro";
+
+/**
+ * Dynamic robots.txt endpoint per Astro's sitemap docs:
+ * https://docs.astro.build/en/guides/integrations-guide/sitemap/#sitemap-link-in-robotstxt
+ *
+ * Reads `site` from the route context so a fork that updates `site:` in
+ * astro.config.mjs propagates here automatically.
+ */
+const getRobotsTxt = (sitemapURL: URL) => `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemapURL = new URL("sitemap-index.xml", site);
+  return new Response(getRobotsTxt(sitemapURL), {
+    headers: { "Content-Type": "text/plain" },
+  });
+};


### PR DESCRIPTION
## Summary

Adds a dynamic robots.txt endpoint pointing crawlers at the sitemap, following Astro's documented pattern at `/en/guides/integrations-guide/sitemap/#sitemap-link-in-robotstxt`.

## Implements

Closes #57

## What changed

- New `src/pages/robots.txt.ts` exporting a `GET` handler that reads `site` from the route context and returns `text/plain` with:
  ```
  User-agent: *
  Allow: /

  Sitemap: <site>/sitemap-index.xml
  ```
- Dynamic (not a static file in `public/`) so a fork updating `site:` in `astro.config.mjs` automatically propagates the change here

## Test plan

- [x] `npm run build` succeeds; `dist/robots.txt` contains the expected output with `https://stargarden.pages.dev/sitemap-index.xml` as the sitemap URL
- [x] `npm test` passes
- [x] `npm run format:check` passes
- [ ] CI green