### PR TITLE
chore: template hygiene grab-bag (footer, private, preview:search, prerender)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "type": "module",
   "version": "1.8.2",
   "license": "MIT",
-  "private": true,
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "preview:search": "npm run build && astro preview",
     "astro": "astro",
     "test": "vitest",
     "test:e2e": "playwright test",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,8 +9,8 @@
     <div class="grid grid-flow-col gap-4">
       <!-- YouTube -->
       <a
-        href="https://www.youtube.com/@astrodotbuild"
-        aria-label="Astro YouTube"
+        href="https://www.youtube.com/@StarGarden"
+        aria-label="StarGarden YouTube"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -27,7 +27,7 @@
         </svg>
       </a>
       <!-- Email icon link -->
-      <a href="mailto:hi@moxiebytes.com" aria-label="Email Astro">
+      <a href="mailto:hello@example.com" aria-label="Email StarGarden">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection, getEntry, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
-export const prerender = true;
 import { Image } from "astro:assets";
 export async function getStaticPaths() {
   const posts = await getCollection("posts", ({ data }) => !data.draft);


### PR DESCRIPTION
## Summary

Four small unrelated polish items, each its own commit.

## Implements

Closes #58

## What changed

### Footer placeholder cleanup
- YouTube link `@astrodotbuild` → `@StarGarden` (matches existing JSON-LD `sameAs`)
- Email `hi@moxiebytes.com` → `hello@example.com` (the template author's personal email shouldn't ship as a placeholder)
- GitHub link unchanged

### Remove `"private": true`
Vestigial for an open-source template that ships via `degit` / GitHub "Use this template". The official Astro blog example does not set it.

### Add `preview:search` npm script
`"preview:search": "npm run build && astro preview"`. Names the workflow for testing Pagefind locally since Pagefind only indexes built HTML.

### Remove redundant `prerender` export
Repo runs in default static mode; the export had no effect. Docs at `/en/guides/on-demand-rendering/`: *"By default, your entire Astro site will be prerendered."*

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes
- [x] `npm run format:check` passes
- [x] Built `/posts/black-holes/` still rendered correctly after `prerender` removal
- [ ] CI green