### PR TITLE
fix!: honor prefers-color-scheme and pair light/dark expressive-code themes

### DIFF
--- a/__tests__/astroConfig.test.ts
+++ b/__tests__/astroConfig.test.ts
@@ -20,6 +20,7 @@ interface IntegrationStub<TOptions = Record<string, unknown>> {
  */
 interface ExpressiveCodeOptions {
   readonly themes: string[];
+  readonly themeCssSelector?: (theme: { name: string }) => string;
   readonly styleOverrides: {
     readonly borderRadius: string;
     readonly frames: {
@@ -103,10 +104,17 @@ describe("astro.config.mjs", () => {
     expect(vitePlugins[0]).toBe(tailwindPluginStub);
   });
 
-  it("passes expressive code theme overrides for consistent syntax styling", () => {
+  it("pairs light + dark expressive-code themes that switch via DaisyUI data-theme", () => {
     expect(expressiveCodeInvocations).toHaveLength(1);
     const [invocation] = expressiveCodeInvocations;
-    expect(invocation.themes).toEqual(["github-dark"]);
+    expect(invocation.themes).toEqual(["github-light", "github-dark"]);
+    expect(typeof invocation.themeCssSelector).toBe("function");
+    expect(invocation.themeCssSelector!({ name: "github-light" })).toBe(
+      '[data-theme="corporate"]',
+    );
+    expect(invocation.themeCssSelector!({ name: "github-dark" })).toBe(
+      '[data-theme="business"]',
+    );
     expect(invocation.styleOverrides).toMatchObject({
       borderRadius: "0.5rem",
       frames: { shadowColor: "#124" },

--- a/__tests__/themeController.test.ts
+++ b/__tests__/themeController.test.ts
@@ -1,10 +1,48 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// Import the theme controller logic
-import { setupThemeController } from "../src/scripts/themeController";
+import {
+  getEffectiveTheme,
+  setupThemeController,
+} from "../src/scripts/themeController";
+
+/**
+ * jsdom doesn't implement matchMedia. Each test stubs it to control the
+ * `prefers-color-scheme: dark` branch.
+ */
+function stubMatchMedia(prefersDark: boolean): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark && query.includes("prefers-color-scheme: dark"),
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
+describe("getEffectiveTheme", () => {
+  it("returns the saved value when it is a known theme", () => {
+    expect(getEffectiveTheme("business", false)).toBe("business");
+    expect(getEffectiveTheme("corporate", true)).toBe("corporate");
+  });
+
+  it("falls back to business when no saved theme and OS prefers dark", () => {
+    expect(getEffectiveTheme(null, true)).toBe("business");
+  });
+
+  it("falls back to corporate when no saved theme and OS does not prefer dark", () => {
+    expect(getEffectiveTheme(null, false)).toBe("corporate");
+  });
+
+  it("ignores unrecognized saved values", () => {
+    expect(getEffectiveTheme("mystery", true)).toBe("business");
+    expect(getEffectiveTheme("", false)).toBe("corporate");
+  });
+});
 
 describe("themeController", () => {
   beforeEach(() => {
@@ -12,6 +50,31 @@ describe("themeController", () => {
     localStorage.clear();
     document.body.innerHTML = "";
     document.documentElement.removeAttribute("data-theme");
+    vi.unstubAllGlobals();
+    stubMatchMedia(false);
+  });
+
+  it("respects prefers-color-scheme when no saved theme exists", () => {
+    stubMatchMedia(true);
+    document.body.innerHTML =
+      '<input type="checkbox" class="theme-controller" value="business">';
+    setupThemeController();
+    const cb = document.querySelector<HTMLInputElement>(".theme-controller");
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "business",
+    );
+    expect(cb?.checked).toBe(true);
+  });
+
+  it("defaults to corporate when no saved theme and OS prefers light", () => {
+    document.body.innerHTML =
+      '<input type="checkbox" class="theme-controller" value="business">';
+    setupThemeController();
+    const cb = document.querySelector<HTMLInputElement>(".theme-controller");
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "corporate",
+    );
+    expect(cb?.checked).toBe(false);
   });
 
   it("should set data-theme from localStorage on load", () => {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,10 +14,15 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.mjs";
 
 const expressiveCode = astroExpressiveCode({
-  // You can set configuration options here
-  themes: ["github-dark"],
+  // Pair light + dark themes; switch by DaisyUI's data-theme attribute.
+  // Per /reference/configuration/#themecssselector — overriding the default
+  // selector wires expressive-code's theme switching to the same data-theme
+  // attribute DaisyUI uses, so syntax highlighting always matches the page
+  // theme.
+  themes: ["github-light", "github-dark"],
+  themeCssSelector: (theme) =>
+    `[data-theme="${theme.name === "github-dark" ? "business" : "corporate"}"]`,
   styleOverrides: {
-    // You can also override styles
     borderRadius: "0.5rem",
     frames: {
       shadowColor: "#124",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,12 +16,17 @@ const { title, description, image, noindex } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en" data-theme="corporate">
+<html lang="en">
   <head>
-    <!-- Persisted theme (dark / light) is applied as early as possible -->
+    <!--
+      Persisted theme (dark / light) applied before first paint. When no
+      saved value exists, data-theme is left unset so DaisyUI's CSS-level
+      `--default` and `--prefersdark` modifiers in global.css decide,
+      which honors the OS prefers-color-scheme media query.
+    -->
     <script is:inline>
       const savedTheme = localStorage.getItem("theme");
-      if (savedTheme) {
+      if (savedTheme === "corporate" || savedTheme === "business") {
         document.documentElement.setAttribute("data-theme", savedTheme);
       }
     </script>

--- a/src/scripts/themeController.ts
+++ b/src/scripts/themeController.ts
@@ -1,36 +1,53 @@
 /**
- * Theme controller logic for DaisyUI theme switching (TypeScript version).
- * Syncs all .theme-controller checkboxes and persists theme selection in localStorage.
+ * Theme controller logic for DaisyUI theme switching.
+ * Syncs all .theme-controller checkboxes and persists theme selection in
+ * localStorage, falling back to `prefers-color-scheme` on first visit.
  *
- * This file is intended to be imported by Astro components. The function
- * auto‑runs when loaded so you only need:
- *
- *   <script>
- *     import "../scripts/themeController.ts";
- *   </script>
+ * Imported by ThemeToggle.astro; auto-runs when the module loads.
  */
 
+export type DaisyTheme = "corporate" | "business";
+
+/**
+ * Compute the effective theme name given the persisted choice and the OS
+ * preference. Pure function — three branches:
+ *  - saved value wins
+ *  - else, prefers-dark → business
+ *  - else → corporate
+ */
+export function getEffectiveTheme(
+  saved: string | null,
+  prefersDark: boolean,
+): DaisyTheme {
+  if (saved === "corporate" || saved === "business") {
+    return saved;
+  }
+  return prefersDark ? "business" : "corporate";
+}
+
 export function setupThemeController(): void {
-  // Collect every checkbox that controls the theme.
   const controllers =
     document.querySelectorAll<HTMLInputElement>(".theme-controller");
 
-  // Helper to apply a theme and keep all checkboxes in sync.
-  const applyTheme = (theme: string): void => {
+  const applyTheme = (theme: DaisyTheme): void => {
     document.documentElement.setAttribute("data-theme", theme);
     controllers.forEach((cb) => {
       cb.checked = cb.value === theme;
     });
   };
 
-  // Initialise from localStorage (or fall back to "corporate").
-  const savedTheme = localStorage.getItem("theme") ?? "corporate";
-  applyTheme(savedTheme);
+  const saved = localStorage.getItem("theme");
+  const prefersDark =
+    window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  applyTheme(getEffectiveTheme(saved, prefersDark));
 
-  // Listen for user changes.
   controllers.forEach((cb) => {
     cb.addEventListener("change", () => {
-      const newTheme = cb.checked ? cb.value : "corporate";
+      // Toggling off snaps back to the explicit `corporate` choice so the
+      // user's deliberate "light mode" decision overrides their OS preference.
+      const newTheme: DaisyTheme = cb.checked
+        ? (cb.value as DaisyTheme)
+        : "corporate";
       localStorage.setItem("theme", newTheme);
       applyTheme(newTheme);
     });


### PR DESCRIPTION
## Summary

Fixes three coupled theme-system bugs:
1. Expressive-code locked to dark theme — now pairs github-light + github-dark, mapped to DaisyUI's `data-theme` attribute via `themeCssSelector`
2. `<html data-theme="corporate">` overrode DaisyUI's `--prefersdark` modifier — attribute removed, inline pre-hydration script only sets `data-theme` when localStorage has a value
3. `themeController` ignored OS preference — extracted `getEffectiveTheme(saved, prefersDark)` pure helper with three documented branches

## Implements

Closes #60

## What changed

- `astro.config.mjs`: expressive-code config replaced. `themes: ['github-light', 'github-dark']` + `themeCssSelector` mapping `github-light → corporate` and `github-dark → business`. Per `/reference/configuration/#themecssselector`.
- `Layout.astro`: dropped `data-theme="corporate"` on `<html>`. Inline script only sets the attribute when a recognized saved value exists.
- `src/scripts/themeController.ts`: extracted pure `getEffectiveTheme(saved, prefersDark)` helper. `setupThemeController` reads `matchMedia('(prefers-color-scheme: dark)').matches` (defensively, via optional chaining so jsdom-without-stub doesn't crash on import).
- New vitest tests for `getEffectiveTheme` (4 cases) and prefers-color-scheme behavior in `setupThemeController` (2 cases). matchMedia stubbed via `vi.stubGlobal`.
- `astroConfig.test.ts` asserts the new dual-theme + selector shape.

## Breaking change

Default theme behavior changes — first-time visitors with dark-mode OS preference now get `business` instead of `corporate`. Migration in commit footer.

## Test plan

- [x] `npm test` passes (4 files, 18 tests — 6 new)
- [x] `npm run build` succeeds
- [x] `npm run format:check` passes
- [x] Manual: built site renders code blocks with appropriate light/dark theme per `data-theme` (verified the generated CSS has `[data-theme="corporate"] .ec-...` and `[data-theme="business"] .ec-...` selectors)
- [ ] CI green