### PR TITLE
feat: enable view transitions (ClientRouter) and link prefetch

### DIFF
--- a/__tests__/astroConfig.test.ts
+++ b/__tests__/astroConfig.test.ts
@@ -34,6 +34,7 @@ interface ExpressiveCodeOptions {
  */
 interface AstroConfigShape {
   readonly site?: string;
+  readonly prefetch?: boolean | Record<string, unknown>;
   readonly integrations?: IntegrationStub[];
   readonly vite?: {
     readonly plugins?: PluginStub[];
@@ -119,6 +120,10 @@ describe("astro.config.mjs", () => {
       borderRadius: "0.5rem",
       frames: { shadowColor: "#124" },
     });
+  });
+
+  it("enables link prefetching with the default hover strategy", () => {
+    expect(config.prefetch).toBe(true);
   });
 
   it("wires reading-time and heading-anchor markdown plugins", () => {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,6 +33,7 @@ const expressiveCode = astroExpressiveCode({
 // https://astro.build/config
 export default defineConfig({
   site: "https://stargarden.pages.dev",
+  prefetch: true,
   vite: {
     plugins: [tailwindcss()],
   },

--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -29,4 +29,30 @@ test.describe("theme toggle", () => {
     await page.reload();
     await expect(html).toHaveAttribute("data-theme", "business");
   });
+
+  test("theme state persists across SPA navigations under ClientRouter", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const html = page.locator("html");
+    await expect(html).toHaveAttribute("data-theme", "corporate");
+
+    // Toggle to dark
+    const desktopToggleLabel = page.locator("header > nav.navbar label.swap");
+    await desktopToggleLabel.click();
+    await expect(html).toHaveAttribute("data-theme", "business");
+
+    // Click an internal link — ClientRouter promotes this to an SPA swap
+    await page.locator('header > nav.navbar a[href="/posts/"]').click();
+    await expect(page).toHaveURL(/\/posts\/?$/);
+
+    // data-theme must persist across the SPA nav, and themeController must
+    // have re-bound on astro:page-load so the checkbox stays in sync
+    await expect(html).toHaveAttribute("data-theme", "business");
+    const desktopToggle = page.locator(
+      "header > nav.navbar input.theme-controller",
+    );
+    await expect(desktopToggle).toBeChecked();
+  });
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import { ClientRouter } from "astro:transitions";
 import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
 import BaseHead from "../components/BaseHead.astro";
@@ -36,6 +37,7 @@ const { title, description, image, noindex } = Astro.props;
       image={image}
       noindex={noindex}
     />
+    <ClientRouter />
     <slot name="head" />
   </head>
 

--- a/src/scripts/themeController.ts
+++ b/src/scripts/themeController.ts
@@ -57,10 +57,11 @@ export function setupThemeController(): void {
 /* ------------------------------------------------------------------ */
 /*  Auto‑run when this module is executed in the browser environment. */
 /* ------------------------------------------------------------------ */
+/*  Listen for astro:page-load (fires on initial load AND every SPA   */
+/*  navigation after <ClientRouter /> takes over). Per docs at        */
+/*  /en/guides/view-transitions/#astropage-load — bundled module      */
+/*  scripts only execute once, so we re-bind on every page swap.      */
+/* ------------------------------------------------------------------ */
 if (typeof window !== "undefined") {
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", setupThemeController);
-  } else {
-    setupThemeController();
-  }
+  document.addEventListener("astro:page-load", setupThemeController);
 }


### PR DESCRIPTION
## Summary

Adds Astro's documented `<ClientRouter />` for SPA-style page navigation and enables `prefetch: true` site-wide. Updates the theme controller to re-bind on every SPA page swap.

## Implements

Closes #61

## What changed

- `Layout.astro`: imports `ClientRouter` from `astro:transitions`, renders in `<head>`
- `astro.config.mjs`: `prefetch: true` at top level (default `hover` strategy)
- `src/scripts/themeController.ts`: replaces `DOMContentLoaded` listener with `astro:page-load`. Required because per Astro docs: *"Bundled module scripts... are only ever executed once. After initial execution they will be ignored, even if the script exists on the new page after a transition."*
- `__tests__/astroConfig.test.ts`: asserts `config.prefetch === true`
- `e2e/theme.spec.ts`: new test asserts the theme state and checkbox state persist across an SPA navigation via internal link click

## Test plan

- [x] `npm test` passes (4 files, 19 tests — 1 new)
- [x] `npm run build` succeeds
- [x] `npm run format:check` passes
- [ ] CI green (including the new e2e SPA-persistence assertion)